### PR TITLE
imprive readfile function: treat any whitespace character as delimiter

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -10,7 +10,7 @@ import (
 func readfile(path string) []string {
 
 	var raw []string;
-	reg := regexp.MustCompile(" |\n")
+	reg := regexp.MustCompile(`\s`)
 
 	dat, err := os.ReadFile(path);
 	if (err != nil) {


### PR DESCRIPTION
readfile should treat also tabs and form feed characters as word delimiters.